### PR TITLE
Implemented methods for global explainability for word embedding components

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.19.4
 pandas==1.1.5
-seaborn=0.1.11
+seaborn==0.11.1
 tensorflow==2.4.0
 datasets==1.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy==1.19.4
+pandas==1.1.5
 tensorflow==2.4.0
 datasets==1.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy==1.19.4
 pandas==1.1.5
+seaborn=0.1.11
 tensorflow==2.4.0
 datasets==1.1.3

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,23 @@
+import unittest
+from xswem.exceptions import XSWEMException, UninitializedWeightsException, \
+    DEFAULT_UNINITIALIZED_WEIGHTS_EXCEPTION_MESSAGE
+
+
+class TestExceptions(unittest.TestCase):
+    def __init__(self, method_name):
+        super().__init__(method_name)
+        self.test_message = "foo bar"
+
+    def test_XSWEMException(self):
+        exception = XSWEMException(self.test_message)
+        self.assertEqual(str(exception), self.test_message)
+
+    def test_UninitializedWeightsException(self):
+        exception = UninitializedWeightsException()
+        self.assertEqual(str(exception), DEFAULT_UNINITIALIZED_WEIGHTS_EXCEPTION_MESSAGE)
+        exception = UninitializedWeightsException(self.test_message)
+        self.assertEqual(str(exception), self.test_message)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,6 @@
 import unittest
-from xswem.exceptions import XSWEMException, UninitializedWeightsException, \
-    _DEFAULT_UNINITIALIZED_WEIGHTS_EXCEPTION_MESSAGE
+from xswem.exceptions import XSWEMException, UnbuiltLayersException, \
+    _DEFAULT_UNBUILT_LAYERS_EXCEPTION_MESSAGE
 
 
 class TestExceptions(unittest.TestCase):
@@ -12,10 +12,10 @@ class TestExceptions(unittest.TestCase):
         exception = XSWEMException(self.test_message)
         self.assertEqual(str(exception), self.test_message)
 
-    def test_UninitializedWeightsException(self):
-        exception = UninitializedWeightsException()
-        self.assertEqual(str(exception), _DEFAULT_UNINITIALIZED_WEIGHTS_EXCEPTION_MESSAGE)
-        exception = UninitializedWeightsException(self.test_message)
+    def test_UnbuiltLayersException(self):
+        exception = UnbuiltLayersException()
+        self.assertEqual(str(exception), _DEFAULT_UNBUILT_LAYERS_EXCEPTION_MESSAGE)
+        exception = UnbuiltLayersException(self.test_message)
         self.assertEqual(str(exception), self.test_message)
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,6 @@
 import unittest
 from xswem.exceptions import XSWEMException, UninitializedWeightsException, \
-    DEFAULT_UNINITIALIZED_WEIGHTS_EXCEPTION_MESSAGE
+    _DEFAULT_UNINITIALIZED_WEIGHTS_EXCEPTION_MESSAGE
 
 
 class TestExceptions(unittest.TestCase):
@@ -14,7 +14,7 @@ class TestExceptions(unittest.TestCase):
 
     def test_UninitializedWeightsException(self):
         exception = UninitializedWeightsException()
-        self.assertEqual(str(exception), DEFAULT_UNINITIALIZED_WEIGHTS_EXCEPTION_MESSAGE)
+        self.assertEqual(str(exception), _DEFAULT_UNINITIALIZED_WEIGHTS_EXCEPTION_MESSAGE)
         exception = UninitializedWeightsException(self.test_message)
         self.assertEqual(str(exception), self.test_message)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -100,7 +100,7 @@ class TestXSWEM(tf.test.TestCase):
                 self.model.global_plot_embedding_histogram()
                 expected_data = self.embedding_weights[0].flatten()
                 mock_histplot.assert_called_once()
-                np.testing.assert_array_equal(mock_histplot.call_args.args[0], expected_data)
+                np.testing.assert_array_equal(mock_histplot.call_args[0][0], expected_data)
                 mock_histplot.return_value.set_title.assert_called_once_with("Histogram for Learned Word Embeddings")
                 mock_histplot.return_value.set_xlabel.assert_called_once_with("Embedding Component Value")
                 mock_histplot.return_value.set_ylabel.assert_called_once_with("Frequency")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,7 +2,7 @@ import tensorflow as tf
 import numpy as np
 import pandas as pd
 from xswem.model import XSWEM
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 
 class TestXSWEM(tf.test.TestCase):
@@ -93,6 +93,18 @@ class TestXSWEM(tf.test.TestCase):
         embedding_weights = self.model.get_embedding_weights(return_df=False)
         self.assertIsInstance(embedding_weights, np.ndarray)
         np.testing.assert_array_equal(embedding_weights, self.embedding_weights[0])
+
+    def test_global_plot_embedding_histogram(self):
+        with patch('matplotlib.pyplot.show', new_callable=Mock) as mock_show:
+            with patch('seaborn.histplot', new_callable=Mock) as mock_histplot:
+                self.model.global_plot_embedding_histogram()
+                expected_data = self.embedding_weights[0].flatten()
+                mock_histplot.assert_called_once()
+                np.testing.assert_array_equal(mock_histplot.call_args.args[0], expected_data)
+                mock_histplot.return_value.set_title.assert_called_once_with("Histogram for Learned Word Embeddings")
+                mock_histplot.return_value.set_xlabel.assert_called_once_with("Embedding Component Value")
+                mock_histplot.return_value.set_ylabel.assert_called_once_with("Frequency")
+                mock_show.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,6 @@
 import tensorflow as tf
 import numpy as np
+import pandas as pd
 from xswem.model import XSWEM
 from unittest.mock import patch
 
@@ -79,6 +80,19 @@ class TestXSWEM(tf.test.TestCase):
             expected_dropout_test_sentence_prediction = 0.99998
             self.assertAlmostEqual(dropout_test_sentence_prediction, expected_dropout_test_sentence_prediction,
                                    places=5)
+
+    def test_get_vocab_ordered_by_key(self):
+        self.assertEqual(self.model.get_vocab_ordered_by_key(), ["UNK", "hello", "world"])
+
+    def test_get_embedding_weights(self):
+        embedding_weights = self.model.get_embedding_weights()
+        self.assertIsInstance(embedding_weights, pd.DataFrame)
+        self.assertEqual(list(embedding_weights.columns), [0, 1])
+        self.assertEqual(list(embedding_weights.index), ["UNK", "hello", "world"])
+        np.testing.assert_array_equal(embedding_weights.to_numpy(), self.embedding_weights[0])
+        embedding_weights = self.model.get_embedding_weights(return_df=False)
+        self.assertIsInstance(embedding_weights, np.ndarray)
+        np.testing.assert_array_equal(embedding_weights, self.embedding_weights[0])
 
 
 if __name__ == '__main__':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import Mock
 from xswem.utils import assert_layers_built
 from xswem.exceptions import UnbuiltLayersException
 
@@ -8,10 +9,6 @@ class TestUtils(unittest.TestCase):
     def test_assert_layers_built(self):
         output = "pass"
 
-        class Layer(object):
-            def __init__(self, built):
-                self.built = built
-
         class Model(object):
             def __init__(self, layers):
                 self.layers = layers
@@ -20,10 +17,15 @@ class TestUtils(unittest.TestCase):
             def get_output(self):
                 return output
 
-        built_model = Model([Layer(True), Layer(True)])
+        mock_layer_built = Mock()
+        mock_layer_built.built = True
+        mock_layer_unbuilt = Mock()
+        mock_layer_unbuilt.built = False
+
+        built_model = Model([mock_layer_built, mock_layer_built])
         self.assertEqual(built_model.get_output(), output)
 
-        unbuilt_model = Model([Layer(True), Layer(False)])
+        unbuilt_model = Model([mock_layer_built, mock_layer_unbuilt])
         with self.assertRaises(UnbuiltLayersException):
             unbuilt_model.get_output()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,32 @@
+import unittest
+from xswem.utils import assert_layers_built
+from xswem.exceptions import UnbuiltLayersException
+
+
+class TestUtils(unittest.TestCase):
+
+    def test_assert_layers_built(self):
+        output = "pass"
+
+        class Layer(object):
+            def __init__(self, built):
+                self.built = built
+
+        class Model(object):
+            def __init__(self, layers):
+                self.layers = layers
+
+            @assert_layers_built
+            def get_output(self):
+                return output
+
+        built_model = Model([Layer(True), Layer(True)])
+        self.assertEqual(built_model.get_output(), output)
+
+        unbuilt_model = Model([Layer(True), Layer(False)])
+        with self.assertRaises(UnbuiltLayersException):
+            unbuilt_model.get_output()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/xswem/exceptions.py
+++ b/xswem/exceptions.py
@@ -1,0 +1,20 @@
+DEFAULT_UNINITIALIZED_WEIGHTS_EXCEPTION_MESSAGE = "Model weights are not initialised. Train the model before calling " \
+                                                "an explain method."
+
+
+class XSWEMException(Exception):
+    """ Base class for exceptions in XSWEM """
+
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return self.message
+
+
+class UninitializedWeightsException(XSWEMException):
+    """ Raised when a method requires the model weights to be initialized but they are uninitialized. """
+
+    def __init__(self, message=None):
+        message = message or DEFAULT_UNINITIALIZED_WEIGHTS_EXCEPTION_MESSAGE
+        super(UninitializedWeightsException, self).__init__(message)

--- a/xswem/exceptions.py
+++ b/xswem/exceptions.py
@@ -1,5 +1,5 @@
-_DEFAULT_UNINITIALIZED_WEIGHTS_EXCEPTION_MESSAGE = "Model weights are not initialised. Train the model before calling " \
-                                                "an explain method."
+_DEFAULT_UNBUILT_LAYERS_EXCEPTION_MESSAGE = "Some layers in the model are not built. Train the model before " \
+                                            "calling this method."
 
 
 class XSWEMException(Exception):
@@ -12,9 +12,9 @@ class XSWEMException(Exception):
         return self.message
 
 
-class UninitializedWeightsException(XSWEMException):
-    """ Raised when a method requires the model weights to be initialized but they are uninitialized. """
+class UnbuiltLayersException(XSWEMException):
+    """ Raised when a method requires the model's layers to be built but they are not. """
 
     def __init__(self, message=None):
-        message = message or _DEFAULT_UNINITIALIZED_WEIGHTS_EXCEPTION_MESSAGE
-        super(UninitializedWeightsException, self).__init__(message)
+        message = message or _DEFAULT_UNBUILT_LAYERS_EXCEPTION_MESSAGE
+        super(UnbuiltLayersException, self).__init__(message)

--- a/xswem/exceptions.py
+++ b/xswem/exceptions.py
@@ -1,4 +1,4 @@
-DEFAULT_UNINITIALIZED_WEIGHTS_EXCEPTION_MESSAGE = "Model weights are not initialised. Train the model before calling " \
+_DEFAULT_UNINITIALIZED_WEIGHTS_EXCEPTION_MESSAGE = "Model weights are not initialised. Train the model before calling " \
                                                 "an explain method."
 
 
@@ -16,5 +16,5 @@ class UninitializedWeightsException(XSWEMException):
     """ Raised when a method requires the model weights to be initialized but they are uninitialized. """
 
     def __init__(self, message=None):
-        message = message or DEFAULT_UNINITIALIZED_WEIGHTS_EXCEPTION_MESSAGE
+        message = message or _DEFAULT_UNINITIALIZED_WEIGHTS_EXCEPTION_MESSAGE
         super(UninitializedWeightsException, self).__init__(message)

--- a/xswem/model.py
+++ b/xswem/model.py
@@ -1,5 +1,7 @@
 import tensorflow as tf
 import pandas as pd
+import seaborn as sns
+from matplotlib import pyplot as plt
 from xswem.utils import assert_layers_built
 
 
@@ -93,3 +95,12 @@ class XSWEM(tf.keras.Model):
             return pd.DataFrame(embedding_weights, index=self.get_vocab_ordered_by_key())
         else:
             return embedding_weights
+
+    def global_plot_embedding_histogram(self):
+        """ Plots a histogram of the flattened embedding weights """
+        embedding_weights_flat = self.get_embedding_weights(return_df=False).flatten()
+        ax = sns.histplot(embedding_weights_flat)
+        ax.set_title("Histogram for Learned Word Embeddings")
+        ax.set_xlabel("Embedding Component Value")
+        ax.set_ylabel("Frequency")
+        plt.show()

--- a/xswem/model.py
+++ b/xswem/model.py
@@ -86,8 +86,11 @@ class XSWEM(tf.keras.Model):
             Returns
             -------
             pd.DataFrame or np.array
-                If return_df, then returns a DataFrame of the embedding weights with the embeddings labelled with their
-                corresponding words. Otherwise returns a numpy array of the embeddings weights.
+                If return_df, then returns a DataFrame of the embedding weights. Each row in the DataFrame corresponds
+                to a word in the vocabulary. The index describes the corresponding word for each row. The column
+                describes which component the weights are for, and are labelled 0 to number_of_components-1. If
+                return_df is False, then returns a numpy array of the embeddings weights in the same format as the
+                DataFrame.
         """
         return_df = return_df if return_df is not None else True
         embedding_weights = self.embedding_layer.weights[0].numpy()
@@ -97,10 +100,37 @@ class XSWEM(tf.keras.Model):
             return embedding_weights
 
     def global_plot_embedding_histogram(self):
-        """ Plots a histogram of the flattened embedding weights """
+        """ Plots a histogram of the flattened embedding weights. This graph is equivalent to figure 1 in the original
+            paper.
+        """
         embedding_weights_flat = self.get_embedding_weights(return_df=False).flatten()
         ax = sns.histplot(embedding_weights_flat)
         ax.set_title("Histogram for Learned Word Embeddings")
         ax.set_xlabel("Embedding Component Value")
         ax.set_ylabel("Frequency")
         plt.show()
+
+    def global_explain_embedding_components(self, n=None):
+        """ Gets the words corresponding to the n largest values for each component of the word embedding. These can be
+            analysed to determine the meaning of each component (column) as discussed in section 4.1.1 of the original
+            paper.
+
+            Parameters
+            ----------
+            n : int
+                Number of words to return for each component. Default of 5 as proposed in the original paper.
+
+            Returns
+            -------
+            pd.DataFrame
+                Returns a DataFrame similar to table 3 in the original paper. The columns describe which component the
+                values are for, and are labelled 0 to number_of_components-1. The values in each column are the words
+                corresponding to the n largest values for the described component, sorted from the largest to smallest
+                values.
+        """
+        n = n or 5
+        embedding_weights = self.get_embedding_weights()
+        explained_components = {**{"Word Rank": range(1, n + 1)},
+                                **{column_name: embedding_weights.nlargest(n, columns=column_name).index
+                                   for column_name in embedding_weights.columns}}
+        return pd.DataFrame.from_dict(explained_components).set_index("Word Rank")

--- a/xswem/utils.py
+++ b/xswem/utils.py
@@ -1,0 +1,21 @@
+import functools
+from xswem.exceptions import UnbuiltLayersException
+
+
+def assert_layers_built(f):
+    """ Wraps function f with method that checks if the model's layers are built, and if not throw an
+        UnbuiltLayersException.
+
+        Parameters
+        ----------
+        f : function
+            Non-static function to wrap with the check method.
+    """
+
+    @functools.wraps(f)
+    def decor(self, *args, **kwargs):
+        if not all(layer.built for layer in self.layers):
+            raise UnbuiltLayersException()
+        return f(self, *args, **kwargs)
+
+    return decor


### PR DESCRIPTION
These methods can be used to provide global explanations for word embedding components as described in section 4.1.1 of the original paper.